### PR TITLE
chore: update rust_sdk

### DIFF
--- a/contract-rs/Cargo.toml
+++ b/contract-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract"
-description = "GuestBook Example Contract"
+description = "Guest Book Example"
 version = "0.1.0"
 edition = "2021"
 # TODO: Fill out the repository field to help NEAR ecosystem tools to discover your project.
@@ -13,10 +13,10 @@ crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-near-sdk = "5.0.0"
+near-sdk = "5.1.0"
 
 [dev-dependencies]
-near-sdk = { version = "5.0.0", features = ["unit-testing"] }
+near-sdk = { version = "5.1.0", features = ["unit-testing"] }
 near-workspaces = { version = "0.10.0", features = ["unstable"] }
 tokio = { version = "1.12.0", features = ["full"] }
 serde_json = "1"

--- a/contract-rs/src/lib.rs
+++ b/contract-rs/src/lib.rs
@@ -1,15 +1,11 @@
 // Find all our documentation at https://docs.near.org
-use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::U64;
-use near_sdk::serde::Serialize;
 use near_sdk::store::Vector;
-use near_sdk::{env, near_bindgen, AccountId, NearToken};
+use near_sdk::{env, near, AccountId, NearToken};
 
 const POINT_ONE: NearToken = NearToken::from_millinear(100);
 
-#[derive(BorshDeserialize, BorshSerialize, Serialize)]
-#[serde(crate = "near_sdk::serde")]
-#[borsh(crate = "near_sdk::borsh")]
+#[near(serializers = [borsh, json])]
 pub struct PostedMessage {
     pub premium: bool,
     pub sender: AccountId,
@@ -17,9 +13,7 @@ pub struct PostedMessage {
 }
 
 // Define the contract structure
-#[near_bindgen]
-#[derive(BorshDeserialize, BorshSerialize)]
-#[borsh(crate = "near_sdk::borsh")]
+#[near(contract_state)]
 pub struct Contract {
     messages: Vector<PostedMessage>,
 }
@@ -34,7 +28,7 @@ impl Default for Contract {
 }
 
 // Implement the contract structure
-#[near_bindgen]
+#[near]
 impl Contract {
     // Public Method - Adds a message to the vector
     #[payable]


### PR DESCRIPTION
updates rust sdk to 5.1 making use of #[near] and #[near(contract_state)]