### PR TITLE
handle if messages are less than 10

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,7 +25,8 @@ function App() {
 
   const getLast10Messages = async () => {
     const total_messages = await wallet.viewMethod({ contractId: CONTRACT_NAME, method: "total_messages" });
-    return wallet.viewMethod({ contractId: CONTRACT_NAME, method: "get_messages", args: { from_index: String(total_messages - 10), limit: "10" } });
+    const from_index = total_messages >= 10 ? total_messages - 10 : 0;
+    return wallet.viewMethod({ contractId: CONTRACT_NAME, method: "get_messages", args: { from_index: String(from_index), limit: "10" } });
   }
 
   const onSubmit = async (e) => {


### PR DESCRIPTION
If there are less than 10 messages, for example when the contract is freshly deployed, the frontend should not request `from_index: "-10"`.