### PR TITLE
fix frontend link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains example implementations of a Guest Book smart contract 
 
 - [Guest Book TS Example](contract-ts)
 - [Guest Book RS Example](contract-rs)
-- [Guest Book Frontend Example](Frontend)
+- [Guest Book Frontend Example](frontend)
 
 <br />
 


### PR DESCRIPTION
link to the frontend is broken due to a case sensitive link